### PR TITLE
FEAT: aarch64 - FAILS: emulated generates wrong zig1.wasm

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,7 +15,7 @@ jobs:
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-aarch64:alma9
 libxml2_devel:
 - '2.14'
 target_platform:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @MementoRC @xmnlab
+* @MementoRC @tdejager @xmnlab

--- a/README.md
+++ b/README.md
@@ -202,5 +202,6 @@ Feedstock Maintainers
 =====================
 
 * [@MementoRC](https://github.com/MementoRC/)
+* [@tdejager](https://github.com/tdejager/)
 * [@xmnlab](https://github.com/xmnlab/)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Summary: Zig is a general-purpose programming language and toolchain for maintai
 
 Development: https://github.com/ziglang/zig
 
-Documentation: https://ziglang.org/documentation/0.15.1/
+Documentation: https://ziglang.org/documentation/0.15.2/
 
 Zig is a general-purpose programming language and toolchain for maintaining robust, optimal, and reusable software.
 Robust: Behavior is correct even for edge cases such as out of memory.

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,7 +2,7 @@ build_platform:
   linux_ppc64le: linux_64
   osx_arm64: osx_64
 provider:
-  linux_aarch64: azure
+  linux_aarch64: default
 conda_forge_output_validation: true
 github:
   branch_name: main

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,8 @@
 build_platform:
-  linux_aarch64: linux_64
   linux_ppc64le: linux_64
   osx_arm64: osx_64
+provider:
+  linux_aarch64: azure
 conda_forge_output_validation: true
 github:
   branch_name: main

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,7 +11,7 @@ version = "3.52.3"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/zig-feedstock"
 authors = ["@conda-forge/zig"]
 channels = ["conda-forge"]
-platforms = ["linux-64", "osx-64", "win-64"]
+platforms = ["linux-64", "linux-aarch64", "osx-64", "win-64"]
 
 [dependencies]
 conda-build = ">=24.1"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,10 +9,10 @@ else
 fi
 
 case "${target_platform}" in
-  linux-64|osx-64|win-64|linux-ppc64le)
+  linux-64|osx-64|win-64|linux-ppc64le|linux-aarch64)
     bash "${RECIPE_DIR}"/build_scripts/native-"${builder}-${target_platform}".sh
     ;;
-  linux-aarch64|osx-arm64)
+  osx-arm64)
     bash "${RECIPE_DIR}"/build_scripts/cross-"${builder}-${target_platform}".sh
     ;;
   *)

--- a/recipe/build_scripts/native-cmake-linux-aarch64.sh
+++ b/recipe/build_scripts/native-cmake-linux-aarch64.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# --- Functions ---
+
+source "${RECIPE_DIR}/build_scripts/_functions.sh"
+
+# --- Main ---
+
+export ZIG_GLOBAL_CACHE_DIR="${PWD}/zig-global-cache"
+export ZIG_LOCAL_CACHE_DIR="${PWD}/zig-local-cache"
+
+cmake_build_dir="${SRC_DIR}/build-release"
+mkdir -p "${cmake_build_dir}" && cp -r "${SRC_DIR}"/zig-source/* "${cmake_build_dir}"
+
+SYSROOT_ARCH="aarch64"
+
+EXTRA_CMAKE_ARGS+=( \
+  "-DCMAKE_BUILD_TYPE=Release" \
+  "-DZIG_SHARED_LLVM=ON" \
+  "-DZIG_USE_LLVM_CONFIG=ON" \
+  "-DZIG_TARGET_TRIPLE=${SYSROOT_ARCH}-linux-gnu" \
+  "-DZIG_TARGET_MCPU=baseline" \
+)
+
+# Zig searches for libm.so/libc.so in incorrect paths (libm.so with hard-coded /usr/lib64/libmvec_nonshared.a)
+modify_libc_libm_for_zig "${BUILD_PREFIX}"
+
+# When using installed c++ libs, zig needs libzigcpp.a
+configure_cmake_zigcpp "${cmake_build_dir}" "${PREFIX}"
+cmake_build_install "${cmake_build_dir}"

--- a/recipe/build_scripts/native-cmake-linux-aarch64.sh
+++ b/recipe/build_scripts/native-cmake-linux-aarch64.sh
@@ -15,12 +15,16 @@ mkdir -p "${cmake_build_dir}" && cp -r "${SRC_DIR}"/zig-source/* "${cmake_build_
 
 SYSROOT_ARCH="aarch64"
 
+# Force zig1.wasm to generate x86_64 code for bootstrap (zig2.c, compiler_rt.c)
+# to avoid aarch64 assembly generation bug in zig1.wasm
+# The final stage3 compiler will still target aarch64
 EXTRA_CMAKE_ARGS+=( \
   "-DCMAKE_BUILD_TYPE=Release" \
   "-DZIG_SHARED_LLVM=ON" \
   "-DZIG_USE_LLVM_CONFIG=ON" \
   "-DZIG_TARGET_TRIPLE=${SYSROOT_ARCH}-linux-gnu" \
   "-DZIG_TARGET_MCPU=baseline" \
+  "-DZIG_HOST_TARGET_TRIPLE=x86_64-linux-gnu" \
 )
 
 # Zig searches for libm.so/libc.so in incorrect paths (libm.so with hard-coded /usr/lib64/libmvec_nonshared.a)

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,11 +17,6 @@ source:
       - if: x86_64 or (linux and aarch64)
         then:
           - patches/0001-x86-maxrss-CMakeLists.txt.patch
-      - if: linux and aarch64
-        then:
-          - patches/0001-cross-findllvm.patch
-          - patches/0002-cross-CMakeLists.txt.patch
-          - patches/0003-cross-install.cmake.patch
       - if: win
         then:
           # May be combined into a single patch once the build is found robust (few versions of zig)
@@ -71,7 +66,7 @@ requirements:
     - ${{ compiler('c') }}
     - ${{ compiler('cxx') }}
     - zig
-    - if: linux and (aarch64 or ppc64le)
+    - if: linux and ppc64le
       then:
         - ${{ c_stdlib }}_${{ build_platform }} >=${{ c_stdlib_version }}
     - ${{ stdlib("c") }}
@@ -85,7 +80,7 @@ requirements:
         - sed
 
   host:
-    - if: linux and (aarch64 or ppc64le)
+    - if: linux and ppc64le
       then:
         - ${{ compiler('cxx') }}
     - clangdev ${{ llvm_version }}.*
@@ -97,22 +92,19 @@ requirements:
     - llvmdev ${{ llvm_version }}.*
     - llvm ${{ llvm_version }}.*
     - lld ${{ llvm_version }}.*
-    - if: linux and (aarch64 or ppc64le)
+    - if: linux and ppc64le
       then:
         - sysroot_${{ target_platform }} >=2.28
     - zlib
     - zstd
 
   run:
-    - if: linux and (aarch64 or ppc64le)
+    - if: linux and ppc64le
       then:
         - sysroot_${{ target_platform }} >=2.28
 
   ignore_run_exports:
     by_name:
-      - if: linux and aarch64
-        then:
-          - __glibc
       - if: win
         then:
           - ucrt

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: zig
-  version: 0.15.1
+  version: 0.15.2
   llvm_version: "20"
 
 package:
@@ -11,7 +11,7 @@ package:
 
 source:
   - url: https://github.com/ziglang/zig/archive/refs/tags/${{ version }}.tar.gz
-    sha256: f7d587087e551a206ad2e1c1a10e8124f5ecaec1f1efc69b0de6df89af80245c
+    sha256: ebe6eb7006f6bbb72e54bd25d0675f2794084909d63a95aa315f2dcf2af5fd99
     patches:
       # Only apply CMake patch when building with CMake (x86_64 or linux-aarch64)
       - if: x86_64 or (linux and aarch64)
@@ -51,7 +51,7 @@ source:
   #   sha256: 473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982
 
 build:
-  number: 2
+  number: 0
   skip:
     - ppc64le
   script:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
