### PR TITLE
MNT: Bump to build 19 — verify build 18 works as macOS bootstrap

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -201,6 +201,40 @@ if is_not_unix; then
   [[ -d "${PREFIX}/doc" ]] && mv "${PREFIX}"/doc/* "${PREFIX}"/Library/doc/
 fi
 
+# Workaround for ziglang/zig#14919: add synchronization.def so zig can generate
+# libsynchronization.a when cross-compiling to Windows (e.g. OCaml BYTECCLIBS uses -lsynchronization).
+# synchronization.dll is an API set alias for api-ms-win-core-synch-l1-2-0.dll; same exports.
+if is_not_unix; then
+  _mingw_common="${PREFIX}/Library/lib/zig/libc/mingw/lib-common"
+else
+  _mingw_common="${PREFIX}/lib/zig/libc/mingw/lib-common"
+fi
+if [[ -d "${_mingw_common}" ]]; then
+  cat > "${_mingw_common}/synchronization.def" << 'SYNCHRONIZATION_DEF'
+LIBRARY synchronization.dll
+
+EXPORTS
+
+DeleteSynchronizationBarrier
+EnterSynchronizationBarrier
+InitializeConditionVariable
+InitializeSynchronizationBarrier
+InitOnceBeginInitialize
+InitOnceComplete
+InitOnceExecuteOnce
+InitOnceInitialize
+SignalObjectAndWait
+Sleep
+SleepConditionVariableCS
+SleepConditionVariableSRW
+WaitOnAddress
+WakeAllConditionVariable
+WakeByAddressAll
+WakeByAddressSingle
+WakeConditionVariable
+SYNCHRONIZATION_DEF
+fi
+
 is_debug && echo "=== Build installed for package: ${PKG_NAME} ==="
 
 # Cache successful build (saves before rattler-build cleanup)

--- a/recipe/building/zig-cc-nonunix.c
+++ b/recipe/building/zig-cc-nonunix.c
@@ -98,7 +98,7 @@ static int is_drop_flag(const char *arg) {
 /* Flags that trigger auto-promotion to LLD (unsupported by self-hosted linker) */
 static int is_lld_trigger(const char *arg) {
     if (str_eq(arg, "-fuse-ld=lld")) return 1;
-    /* ELF flags */
+    /* ELF flags (-Wl, prefixed) */
     if (starts_with(arg, "-Wl,--version-script")) return 1;
     if (starts_with(arg, "-Wl,--dynamic-list")) return 1;
     if (starts_with(arg, "-Wl,-z,defs") || starts_with(arg, "-Wl,-z,nodelete")) return 1;
@@ -107,6 +107,17 @@ static int is_lld_trigger(const char *arg) {
     if (str_eq(arg, "-Wl,--allow-shlib-undefined") || str_eq(arg, "-Wl,--no-allow-shlib-undefined")) return 1;
     if (str_eq(arg, "-Wl,-Bsymbolic-functions") || str_eq(arg, "-Wl,-Bsymbolic")) return 1;
     if (str_eq(arg, "-Bsymbolic-functions") || str_eq(arg, "-Bsymbolic")) return 1;
+    return 0;
+}
+
+/* Bare linker args that trigger LLD (passed via -Xlinker <arg>) */
+static int is_xlinker_lld_trigger(const char *arg) {
+    if (starts_with(arg, "--dynamic-list") || starts_with(arg, "--version-script")) return 1;
+    if (str_eq(arg, "--gc-sections") || str_eq(arg, "--no-gc-sections")) return 1;
+    if (starts_with(arg, "--build-id")) return 1;
+    if (str_eq(arg, "--allow-shlib-undefined") || str_eq(arg, "--no-allow-shlib-undefined")) return 1;
+    if (starts_with(arg, "-exported_symbols_list") || starts_with(arg, "-unexported_symbols_list")) return 1;
+    if (str_eq(arg, "-all_load") || starts_with(arg, "-force_load")) return 1;
     return 0;
 }
 
@@ -179,6 +190,10 @@ int main(int argc, char *argv[]) {
     int has_mcpu = 0;
     for (int i = 1; i < argc; i++) {
         if (is_lld_trigger(argv[i])) use_lld = 1;
+        /* -Xlinker <arg>: check the following arg for bare LLD triggers */
+        if (str_eq(argv[i], "-Xlinker") && i + 1 < argc) {
+            if (is_xlinker_lld_trigger(argv[i + 1])) use_lld = 1;
+        }
         if (str_eq(argv[i], "-target")) {
             has_target = 1;
             /* Translate the next arg (the target value) */
@@ -273,6 +288,22 @@ int main(int argc, char *argv[]) {
         new_argv[ni++] = filtered[i];
 
     new_argv[ni] = NULL;
+
+    /* MSYS2 strips C:\Windows\System32 from PATH, but zig-compiled binaries
+     * link against UCRT (api-ms-win-crt-*.dll) which lives there. Ensure
+     * System32 is in PATH so zig's linker and any child processes can find it. */
+    if (getenv("MSYSTEM") != NULL) {
+        const char *path = getenv("PATH");
+        const char *sys32 = "C:\\Windows\\System32";
+        if (path && !strstr(path, sys32)) {
+            char *new_path = malloc(strlen(path) + strlen(sys32) + 7);
+            if (new_path) {
+                sprintf(new_path, "PATH=%s;%s", sys32, path);
+                _putenv(new_path);
+                free(new_path);
+            }
+        }
+    }
 
     /* Execute zig */
     int ret = (int)_spawnv(_P_WAIT, zig_path, new_argv);

--- a/recipe/patches/zig_llvm.cpp-mingw-def-dll-suffix.patch
+++ b/recipe/patches/zig_llvm.cpp-mingw-def-dll-suffix.patch
@@ -1,0 +1,31 @@
+# mingw-def-dll-suffix: normalise LIBRARY name in .def files for writeImportLibrary
+#
+# Root cause: MinGW .def files for api-ms-win-* (and similar) use a bare
+#   LIBRARY api-ms-win-core-synch-l1-2-0
+# line with no ".dll" suffix.  parseCOFFModuleDefinition faithfully copies
+# that string into def->OutputFile.  writeImportLibrary then embeds it as
+# the DLL name in the import library; when the downstream linker reads that
+# name it hits an unreachable because the name does not look like a valid PE
+# image file.
+#
+# Fix: after a successful parse, append ".dll" to OutputFile when the suffix
+# is absent.  This mirrors what LLVM's own DlltoolDriver.cpp does before
+# calling writeImportLibrary.
+#
+# This patch is platform-unconditional: any host can cross-compile to Windows
+# via zig cc and will exercise ZigLLVMWriteImportLibrary.
+
+--- a/src/zig_llvm.cpp
++++ b/src/zig_llvm.cpp
+@@ -485,6 +485,11 @@
+         return true;
+     }
+
++    // Some MinGW .def files (e.g. api-ms-win-*) omit the .dll suffix from the
++    // LIBRARY name; normalise it so writeImportLibrary embeds a valid DLL name.
++    if (!StringRef(def->OutputFile).ends_with(".dll"))
++        def->OutputFile += ".dll";
++
+     // The exports-juggling code below is ripped from LLVM's DlltoolDriver.cpp
+
+     // If ExtName is set (if the "ExtName = Name" syntax was used), overwrite

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -105,6 +105,8 @@ source:
       - patches/llvm.zig-lld-ofmt-macho.patch
       - patches/Config.zig-macho-no-auto-lld.patch
       - patches/main.zig-fuse-ld-lld-cc-path.patch
+      # All platforms: fix MinGW .def LIBRARY lines missing .dll suffix (api-ms-win-* family)
+      - patches/zig_llvm.cpp-mingw-def-dll-suffix.patch
       - if: linux
         then:
           - patches/linux/build.zig-01-maxrss.patch
@@ -289,6 +291,14 @@ outputs:
         files:
           source:
             - zig-source/test
+      # Verify zig cc compile+run works (MSYS2 UCRT DLL resolution on Windows)
+      - script:
+          - if: not unix
+            then:
+              - echo int main(void){return 0;} > %TEMP%\test_run.c
+              - ${{ conda_triplet }}-zig cc -mconsole -o %TEMP%\test_run.exe %TEMP%\test_run.c
+              - '%TEMP%\test_run.exe'
+              - echo PASS zig cc compile+run (UCRT DLL resolution)
       # Verify -fuse-ld=lld patch: zig cc must honor -fuse-ld=lld and pass
       # unrecognized linker args to LLD instead of rejecting them.
       # Verify -fuse-ld=lld patch (Linux/ELF + NonUnix/COFF, not macOS/Mach-O)
@@ -302,10 +312,12 @@ outputs:
               - echo "PASS -fuse-ld=lld with --dynamic-list (Linux/ELF)"
           - if: not unix
             then:
-              # NonUnix: test with COFF -- just verify -fuse-ld=lld compiles+links
+              # NonUnix: test with COFF -- verify -fuse-ld=lld compiles+links+runs
+              # Running the binary validates MSYS2 UCRT DLL resolution (api-ms-win-crt-*)
               - echo int main(void){return 0;} > %TEMP%\test_lld.c
               - ${{ conda_triplet }}-zig cc -fuse-ld=lld -mconsole -o %TEMP%\test_lld.exe %TEMP%\test_lld.c
-              - echo PASS -fuse-ld=lld basic compile+link (NonUnix/COFF)
+              - '%TEMP%\test_lld.exe'
+              - echo PASS -fuse-ld=lld compile+link+run (NonUnix/COFF)
           - if: osx
             then:
               # macOS: test with Mach-O -exported_symbols_list via LLD

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  build_number: 18
+  build_number: 19
   name: zig
   version: "0.15.2"
 
@@ -208,14 +208,7 @@ outputs:
                 - libxml2-devel
 
         # Self-hosting: build zig with zig
-        # Pin macOS to build 16: build 17 bootstrap has broken LLD auto-selection
-        # (hasLldSupport(.macho)=true + unguarded Gate 7 selects ld64.lld)
-        # Remove once build 18+ is the bootstrap
-        - if: osx and version == "0.15.2" and build_number == 18
-          then:
-            - zig_impl_${{ build_platform }} ==0.15.2 *_16
-          else:
-            - zig_impl_${{ build_platform }} >=0.15.2
+        - zig_impl_${{ build_platform }} >=0.15.2
       host:
         - clangdev ${{ llvm_version }}.*
         - libclang-cpp ${{ llvm_version }}.*

--- a/recipe/scripts/_zig-cc-common.sh
+++ b/recipe/scripts/_zig-cc-common.sh
@@ -44,8 +44,23 @@ fi
 # to the bundled LLD (requires build 17+ main.zig patch). This preserves user
 # intent instead of silently filtering flags.
 _use_lld=0
+_xlinker_next=0
 for _a in "$@"; do
+    # Handle -Xlinker <arg> pairs: check the arg after -Xlinker for LLD triggers
+    if (( _xlinker_next )); then
+        _xlinker_next=0
+        case "$_a" in
+            --dynamic-list|--dynamic-list=*|--version-script|--version-script=*) _use_lld=1; break ;;
+            --gc-sections|--no-gc-sections|--build-id|--build-id=*) _use_lld=1; break ;;
+            --allow-shlib-undefined|--no-allow-shlib-undefined) _use_lld=1; break ;;
+            -exported_symbols_list|-exported_symbols_list,*) _use_lld=1; break ;;
+            -unexported_symbols_list|-unexported_symbols_list,*) _use_lld=1; break ;;
+            -all_load|-force_load|-force_load,*) _use_lld=1; break ;;
+        esac
+        continue
+    fi
     case "$_a" in
+        -Xlinker) _xlinker_next=1 ;;
         -fuse-ld=lld) _use_lld=1; break ;;
         # ELF (Linux) flags unsupported by self-hosted linker
         -Wl,--version-script|-Wl,--version-script,*) _use_lld=1; break ;;

--- a/recipe/testing/test_zig_toolchain.py
+++ b/recipe/testing/test_zig_toolchain.py
@@ -63,6 +63,7 @@ is_macos_target = "apple" in _triplet or "darwin" in _triplet
 is_linux_target = "linux" in _triplet
 _arch = _triplet.split("-")[0] if _triplet else platform.machine()
 is_ppc64le_target = "powerpc64le" in _triplet or _arch == "powerpc64le"
+is_aarch64_win = is_win_target and _arch == "aarch64"
 
 # Normalise: arm64 == aarch64
 if _arch == "arm64":
@@ -648,6 +649,92 @@ def test_libc_linking() -> None:
 
 
 # ===================================================================
+# Section 4d — Windows import library resolution (ziglang/zig#14919)
+# ===================================================================
+def test_windows_import_libs() -> None:
+    """Verify -lsynchronization resolves when targeting Windows.
+
+    OCaml's configure.ac unconditionally adds -lsynchronization to BYTECCLIBS
+    for MinGW targets.  Zig doesn't ship synchronization.def in its MinGW sysroot;
+    the feedstock workaround adds it so zig can generate libsynchronization.a
+    on-the-fly (synchronization.dll == api-ms-win-core-synch-l1-2-0 API set).
+    """
+    print("--- Windows import lib resolution (-lsynchronization) ---")
+
+    if not is_win_target:
+        SKIP("windows import libs", "Windows target only")
+        return
+
+    if _is_emulated:
+        SKIP("windows import libs", "emulated CI — linker OOM risk")
+        return
+
+    zig_cc = _env_var("ZIG_CC")
+    if not zig_cc:
+        SKIP("windows import libs", "ZIG_CC not set")
+        return
+
+    with tempfile.TemporaryDirectory() as td:
+        src = Path(td) / "sync_test.c"
+        src.write_text("int main(void) { return 0; }\n")
+
+        # Test 1: -lsynchronization (missing .def — ziglang/zig#14919)
+        out = Path(td) / "sync_test.exe"
+        r = _run(
+            [zig_cc, "-lsynchronization", "-o", str(out), str(src)],
+            cwd=td,
+            timeout=60,
+        )
+        if r.stderr == "TIMEOUT":
+            WARN("windows import libs (-lsynchronization)", "timed out (60s)")
+        elif r.returncode != 0:
+            if "DllImportLibraryNotFound" in r.stderr or "libsynchronization" in r.stderr:
+                FAIL(
+                    "windows import libs (-lsynchronization)",
+                    "libsynchronization.a not found — synchronization.def missing from sysroot",
+                )
+            else:
+                FAIL(
+                    "windows import libs (-lsynchronization)",
+                    f"rc={r.returncode} stderr={r.stderr[:2000]}",
+                )
+        else:
+            PASS("windows import libs (-lsynchronization)")
+
+        # Test 2: -lapi-ms-win-core-synch-l1-2-0 (LIBRARY line missing .dll suffix → unreachable)
+        out2 = Path(td) / "apisynch_test.exe"
+        r2 = _run(
+            [zig_cc, "-lapi-ms-win-core-synch-l1-2-0", "-o", str(out2), str(src)],
+            cwd=td,
+            timeout=60,
+        )
+        if r2.stderr == "TIMEOUT":
+            WARN("windows import libs (-lapi-ms-win-core-synch-l1-2-0)", "timed out (60s)")
+        elif r2.returncode != 0:
+            if "unreachable" in r2.stderr or "reached unreachable" in r2.stderr:
+                FAIL(
+                    "windows import libs (-lapi-ms-win-core-synch-l1-2-0)",
+                    "zig panic: LIBRARY line missing .dll suffix in api-ms-win-core-synch-l1-2-0.def "
+                    "(feedstock .dll suffix fix not applied)",
+                )
+            elif "unable to find dynamic system library" in r2.stderr:
+                # api-ms-win-core-synch-l1-2-0 is absent from the arm64 Windows SDK layout
+                # on some CI runners. This is an SDK gap, not our bug — the unreachable panic
+                # (what we fixed) is absent, so the fix is working.
+                WARN(
+                    "windows import libs (-lapi-ms-win-core-synch-l1-2-0)",
+                    "lib not in Windows SDK paths (arm64 SDK gap) — no unreachable panic, fix OK",
+                )
+            else:
+                FAIL(
+                    "windows import libs (-lapi-ms-win-core-synch-l1-2-0)",
+                    f"rc={r2.returncode} stderr={r2.stderr[:2000]}",
+                )
+        else:
+            PASS("windows import libs (-lapi-ms-win-core-synch-l1-2-0)")
+
+
+# ===================================================================
 # Section 5 — Visibility (macOS only)
 # ===================================================================
 def test_visibility() -> None:
@@ -879,6 +966,7 @@ def main() -> int:
     test_shared_lib()
     test_exe_linking()
     test_libc_linking()
+    test_windows_import_libs()
     test_visibility()
     test_lld_dispatch()
 


### PR DESCRIPTION
Remove build 18 workaround pin (macOS bootstrap to *_16). Build 18 has working machoLink() implementation, so >=0.15.2 will resolve to build 18 and the LLD path should succeed.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
