### PR TITLE
[dev] version bump: 1465+8b2d0ce21 -> 1476+91a29d707

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -231,32 +231,32 @@ source:
       - if: build_platform == "osx-arm64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 215c71456e0cc8994e0c56438d93a4a512d3780a9e6a3a48a8917db7f4cfead9
+            sha256: e75b0d9784b1293cb08ae3e9aa9edd7ee2012abb4138e3d2a1c927870d62f7c3
             target_directory: zig-bootstrap
       - if: build_platform == "osx-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 1dd73a374c9a82c795bd57c64c7a3f33375b1801a9256d7b84b34a579236224a
+            sha256: 6e40bf9c32e4f07e12f26b4af1e51dcf9511e534da193bb807a24594d41fb6ae
             target_directory: zig-bootstrap
       - if: build_platform == "win-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-windows-${{ version }}-dev.${{ snapshot }}.zip
-            sha256: 4cceee91a4ff1679234bab473ff4ea3e3ef89e6f636490110cf8750d9edc272a
+            sha256: 981c6b0d6473e7b83f9bd0ca1c37d04e05cf204251252bdc11a3c19f371f236d
             target_directory: zig-bootstrap
       - if: build_platform == "linux-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 2a196dd43ec51e64b6de3ed0e5f9f217aac88ad187e3ae5db3fe037feddef118
+            sha256: 209ca7256eb54cfef1e607043d091ca997a14c6e191546e52f18ded09df86ec1
             target_directory: zig-bootstrap
       - if: build_platform == "linux-aarch64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 248715e53cdc6fc0ab20083742748f7e262937989f9a1f27a279c2a5f9b529a0
+            sha256: b6eda19827fa660880e437ce79463ecd17c7e532252447c83392559675f6b917
             target_directory: zig-bootstrap
       - if: build_platform == "linux-ppc64le"
         then:
           - url: https://ziglang.org/builds/zig-powerpc64le-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: ebd5a4d3f04ac84c0c2b1c2b2e4468efeb3abf2a42923cf3238260bab391b546
+            sha256: 89914a81149bbb4378612bd4b33a86d60a4ba7f3b57561fca4b482936f0016fe
             target_directory: zig-bootstrap
 
 build:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,7 +5,7 @@ context:
   name: zig
   version: "0.17.0"
   api_version: ${{ version | split(".") | last }}
-  snapshot: "1465+8b2d0ce21"
+  snapshot: "1476+91a29d707"
 
   llvm_src_version: "22.1.6"
   llvm_version: ${{ llvm_src_version | split(".") | first }}
@@ -149,7 +149,7 @@ recipe:
 
 source:
   - url: https://ziglang.org/builds/zig-${{ version }}-dev.${{ snapshot }}.tar.xz
-    sha256: b1bbdf550916d25a45b56223f3029041ce3929311a888a299ed91de2d3c75277
+    sha256: a6b8971a080c277993b935608d02dc17174acf5834cdc16ab53dc0b66f3fc1b5
     patches:
       # All platforms: wire LLD MachO into zig cc pipeline + allow -fuse-ld=lld.
       # macho-lld-support must apply before prefer-shared-libcxx because the


### PR DESCRIPTION
Automated zig master version bump.

- version: 0.17.0 -> 0.17.0
- tarball: https://ziglang.org/builds/zig-0.17.0-dev.1476+91a29d707.tar.xz
- sha256: a6b8971a080c277993b935608d02dc17174acf5834cdc16ab53dc0b66f3fc1b5

Patch relevancy gate:
### linux-64

### win-64


Auto-generated by MementoRC/zig-feedstock's .github/workflows/zig-nightly-snapshot.yml -- verify FAIL/DRIFT/large-OFFSET findings above before merging. Diff is scoped to recipe/recipe.yaml only.