### PR TITLE
[dev] version bump: 1503+1f1bee62e -> 1509+bb296ab9b

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,7 +5,7 @@ context:
   name: zig
   version: "0.17.0"
   api_version: ${{ version | split(".") | last }}
-  snapshot: "1503+1f1bee62e"
+  snapshot: "1509+bb296ab9b"
 
   llvm_src_version: "22.1.6"
   llvm_version: ${{ llvm_src_version | split(".") | first }}
@@ -149,7 +149,7 @@ recipe:
 
 source:
   - url: https://ziglang.org/builds/zig-${{ version }}-dev.${{ snapshot }}.tar.xz
-    sha256: fdb42508dc28924756082196ac62131661a9fb788e45f9bfd3794531e0d8bc4c
+    sha256: 6b06321d296c2d2cc9b38be81949f714af1cb7481ae6311dd1006b6505499423
     patches:
       # All platforms: wire LLD MachO into zig cc pipeline + allow -fuse-ld=lld.
       # macho-lld-support must apply before prefer-shared-libcxx because the
@@ -230,32 +230,32 @@ source:
       - if: build_platform == "osx-arm64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 9eceb97df77aaec7b8873fe24f74783adbdf0b88e867547e2ea6449f73bfab67
+            sha256: 24bd83c1d435b8ab6192f58afcc22f4e5252077a938ffbc35eaa4ca97c5be709
             target_directory: zig-bootstrap
       - if: build_platform == "osx-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 8fd4c9de8d97626388e38cb4efb523dbc64dd3452d0ab83f829417f7b99f31eb
+            sha256: 087aad38fead6c0ba7a52b5db3c405e63708c4765eda643d4144b9e4933d45e5
             target_directory: zig-bootstrap
       - if: build_platform == "win-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-windows-${{ version }}-dev.${{ snapshot }}.zip
-            sha256: 7513cb63d4cd5953fa0a3868353915350ae7797dc2019c57f758e1089a3c44a3
+            sha256: a4f537761ca1f5274c9bb0e7da598c6e82205a4ea78f329690a26eade555d7e8
             target_directory: zig-bootstrap
       - if: build_platform == "linux-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 15b4c7b9e20883483b94a83bf9da09200c2ea00e7f0741780f3babcf1b460d2c
+            sha256: 48cc865b8b410ec84eaa97e50c2bd7a657871802ce3aaaf04dd1da2294d4b28a
             target_directory: zig-bootstrap
       - if: build_platform == "linux-aarch64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: e2b623c02d32bc18c53896a04e9cf4c0c3a783ff3ced5a70caf4e3deceae88b1
+            sha256: 7f17e09b675cfe39805c5b551b251151f7750b9df8a168538007890c1c00dc8e
             target_directory: zig-bootstrap
       - if: build_platform == "linux-ppc64le"
         then:
           - url: https://ziglang.org/builds/zig-powerpc64le-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 2c0cfc6567c4bea7973b316802abca90dc17691429545e1393032806eaf0eacf
+            sha256: 640f0a87838e1a65da9f4addfa8c8800911906e4f4b8f28732efdf7e9fef8239
             target_directory: zig-bootstrap
 
 build:


### PR DESCRIPTION
Automated zig master version bump.

- version: 0.17.0 -> 0.17.0
- tarball: https://ziglang.org/builds/zig-0.17.0-dev.1509+bb296ab9b.tar.xz
- sha256: 6b06321d296c2d2cc9b38be81949f714af1cb7481ae6311dd1006b6505499423
- bootstrap sha256s patched: osx-arm64,osx-64,win-64,linux-64,linux-aarch64,linux-ppc64le

Patch relevancy gate:
### linux-64

### win-64


Auto-generated by MementoRC/zig-feedstock's .github/workflows/zig-nightly-snapshot.yml -- verify FAIL/DRIFT/large-OFFSET findings above before merging. Diff is scoped to recipe/recipe.yaml only.