### PR TITLE
[dev] version bump: 1509+bb296ab9b -> 1516+8a4b5424d

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,7 +5,7 @@ context:
   name: zig
   version: "0.17.0"
   api_version: ${{ version | split(".") | last }}
-  snapshot: "1509+bb296ab9b"
+  snapshot: "1516+8a4b5424d"
 
   llvm_src_version: "22.1.6"
   llvm_version: ${{ llvm_src_version | split(".") | first }}
@@ -149,7 +149,7 @@ recipe:
 
 source:
   - url: https://ziglang.org/builds/zig-${{ version }}-dev.${{ snapshot }}.tar.xz
-    sha256: 6b06321d296c2d2cc9b38be81949f714af1cb7481ae6311dd1006b6505499423
+    sha256: cc106b77076b1582b8990d589ce8a85222a9cad76199b1a0556b029560375ca7
     patches:
       # All platforms: wire LLD MachO into zig cc pipeline + allow -fuse-ld=lld.
       # macho-lld-support must apply before prefer-shared-libcxx because the
@@ -230,32 +230,32 @@ source:
       - if: build_platform == "osx-arm64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 24bd83c1d435b8ab6192f58afcc22f4e5252077a938ffbc35eaa4ca97c5be709
+            sha256: 7284f4c3dd6efc8881225fcebe45e85f77c999748d73f895e72d3c6fcfb9fe8d
             target_directory: zig-bootstrap
       - if: build_platform == "osx-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 087aad38fead6c0ba7a52b5db3c405e63708c4765eda643d4144b9e4933d45e5
+            sha256: 0d637250297833234c44e66dca71455cae774659a9537aad6ccabbdab75b6571
             target_directory: zig-bootstrap
       - if: build_platform == "win-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-windows-${{ version }}-dev.${{ snapshot }}.zip
-            sha256: a4f537761ca1f5274c9bb0e7da598c6e82205a4ea78f329690a26eade555d7e8
+            sha256: dc0305a930a661b00d61d1ea85f661eb8519caf2b12b5e3f794e0ee0c3ee00f9
             target_directory: zig-bootstrap
       - if: build_platform == "linux-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 48cc865b8b410ec84eaa97e50c2bd7a657871802ce3aaaf04dd1da2294d4b28a
+            sha256: d3cb1d1dbe825ec5cb924b0c399ce0dfbdd27a61ae1097e272bee9f1ca07b311
             target_directory: zig-bootstrap
       - if: build_platform == "linux-aarch64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 7f17e09b675cfe39805c5b551b251151f7750b9df8a168538007890c1c00dc8e
+            sha256: c490b31c891fe1513389cace5bb607aad50616a0e81d9ee83ed148360bdd24f4
             target_directory: zig-bootstrap
       - if: build_platform == "linux-ppc64le"
         then:
           - url: https://ziglang.org/builds/zig-powerpc64le-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 640f0a87838e1a65da9f4addfa8c8800911906e4f4b8f28732efdf7e9fef8239
+            sha256: c70b02cd1e45c414ae606e2e70d7acb0a5982c6ace959aa52d4eeedd25b17845
             target_directory: zig-bootstrap
 
 build:


### PR DESCRIPTION
Automated zig master version bump.

- version: 0.17.0 -> 0.17.0
- tarball: https://ziglang.org/builds/zig-0.17.0-dev.1516+8a4b5424d.tar.xz
- sha256: cc106b77076b1582b8990d589ce8a85222a9cad76199b1a0556b029560375ca7
- bootstrap sha256s patched: osx-arm64,osx-64,win-64,linux-64,linux-aarch64,linux-ppc64le

Patch relevancy gate:
### linux-64

### win-64


Auto-generated by MementoRC/zig-feedstock's .github/workflows/zig-nightly-snapshot.yml -- verify FAIL/DRIFT/large-OFFSET findings above before merging. Diff is scoped to recipe/recipe.yaml only.