### PR TITLE
[dev] fold dev snapshot into build.string (unique package identity)

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -260,6 +260,13 @@ source:
 
 build:
   number: ${{ build_number }}
+  # Fold the dev snapshot into the build string so each nightly snapshot of the
+  # same "0.17.0" base version is a DISTINCT conda package. version is hardcoded
+  # and the variant hash does not depend on `snapshot` (a context var, not a
+  # variant), so without this every snapshot would collide at <hash>_<number>.
+  # `+` is illegal in a build string, so sanitize it to `_`. Inherited by all
+  # outputs (per-key merge); bump_snapshot.py only needs to patch context.snapshot.
+  string: ${{ hash }}_${{ snapshot | replace("+", "_") }}_${{ build_number }}
 
 outputs:
   # ==========================================================================


### PR DESCRIPTION
## Problem

On the `dev` (nightly snapshot) track, `version` is hardcoded `"0.17.0"` and `build_number` stays `0`. The rattler-build variant hash is computed only from variant config, and does **not** depend on the `snapshot` context var (it's a context var, not a variant). The recipe had no `build.string`, so every dev snapshot resolved to the **same** package identity `zig-0.17.0-<hash>_0` and successive snapshots clobbered each other when uploaded to `conda-forge/label/zig_dev`.

## Fix

Add a top-level `build.string` that folds the snapshot into the package identity:

```yaml
build:
  number: ${{ build_number }}
  string: ${{ hash }}_${{ snapshot | replace("+", "_") }}_${{ build_number }}
```

- Inherited by all 4 outputs via rattler-build's per-key top-level `build:` merge (same mechanism already used for `number`).
- `+` is illegal in a build string, so it's sanitized to `_` (e.g. `h<hash>_1525_91c6d8a09_0`).
- `build_number` stays the manual-rebuild escape hatch.
- **`bump_snapshot.py` needs no change** — it already patches `context.snapshot`, which now flows straight into the package identity, so every future automated snapshot PR inherits distinct package identities for free.

Master/dev-channel only: the release/`experimental` lane has no `snapshot` context var and must **not** carry this string (uniqueness there already comes from a changing `version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)