### PR TITLE
[dev] version bump: 1543+6db520a4c -> 1564+97ced1272

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,7 +5,7 @@ context:
   name: zig
   version: "0.17.0"
   api_version: ${{ version | split(".") | last }}
-  snapshot: "1543+6db520a4c"
+  snapshot: "1564+97ced1272"
 
   llvm_src_version: "22.1.6"
   llvm_version: ${{ llvm_src_version | split(".") | first }}
@@ -149,7 +149,7 @@ recipe:
 
 source:
   - url: https://ziglang.org/builds/zig-${{ version }}-dev.${{ snapshot }}.tar.xz
-    sha256: 4d47efd0dc00d35833dfa4721a6126da959d2456135693a03a2da0f624079815
+    sha256: a7d52940bf1af409f5c0c65053a5d7040a3f18ffc3a954e4e24b027895d4f4fe
     patches:
       # All platforms: wire LLD MachO into zig cc pipeline + allow -fuse-ld=lld.
       # macho-lld-support must apply before prefer-shared-libcxx because the
@@ -230,32 +230,32 @@ source:
       - if: build_platform == "osx-arm64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 226a8168e7823eb402120c327787a75f9dd84b166dc2870c963dfb2cbe735f59
+            sha256: d13865a4ee746c79d08fc1f9a1bd1a788c1423205ea5354403ad40d1386b7aed
             target_directory: zig-bootstrap
       - if: build_platform == "osx-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 5e030726bc5a64fcb072cb1036e21130c7fd0391c464cc0d1fa41dad0c3eea74
+            sha256: cb78ba744950d6ff0d022469fe5a400c04c19e27c98b44d157c18e829b58eff3
             target_directory: zig-bootstrap
       - if: build_platform == "win-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-windows-${{ version }}-dev.${{ snapshot }}.zip
-            sha256: 439d447aaa1d9087d2aeaf0be922425910f3dec960ff19bd22fc962945d66f84
+            sha256: 3fbc43463e0999a2f01ba7a85c6ef49749ceecdda2a8df32c210b2e458a29e28
             target_directory: zig-bootstrap
       - if: build_platform == "linux-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 5fd2d09645a5b9e2a0df8f39ac9c131a84f8f2a4000d2f3fde244ee8ae87b536
+            sha256: bc92e8b99eeef771c744fe4173e7960bee7c06158d59779fa1e6ed795dccc6ac
             target_directory: zig-bootstrap
       - if: build_platform == "linux-aarch64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 3620b4491276387ab88d42ab6a2403d3d7d1687805fb2c348e5ee61c02252315
+            sha256: 96c3ad5ac06f920b4539a3ad9e4f1c515eee267a609e15ebd70b47fe3577c869
             target_directory: zig-bootstrap
       - if: build_platform == "linux-ppc64le"
         then:
           - url: https://ziglang.org/builds/zig-powerpc64le-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 628624ead46867c226710ce31c6f5189f86f32d3bd7865615df5a453748d2df8
+            sha256: a8d0fde3cd752b9f87712b4d6e87ece8186cb36086f353caf87614c7efd1e527
             target_directory: zig-bootstrap
 
 build:


### PR DESCRIPTION
Automated zig master version bump.

- version: 0.17.0 -> 0.17.0
- tarball: https://ziglang.org/builds/zig-0.17.0-dev.1564+97ced1272.tar.xz
- sha256: a7d52940bf1af409f5c0c65053a5d7040a3f18ffc3a954e4e24b027895d4f4fe
- bootstrap sha256s patched: osx-arm64,osx-64,win-64,linux-64,linux-aarch64,linux-ppc64le

Patch relevancy gate:
### linux-64

### win-64


Auto-generated by MementoRC/zig-feedstock's .github/workflows/zig-nightly-snapshot.yml -- verify FAIL/DRIFT/large-OFFSET findings above before merging. Diff is scoped to recipe/recipe.yaml only.