### PR TITLE
[dev] version bump: 1564+97ced1272 -> 1567+f0354179a

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,7 +5,7 @@ context:
   name: zig
   version: "0.17.0"
   api_version: ${{ version | split(".") | last }}
-  snapshot: "1564+97ced1272"
+  snapshot: "1567+f0354179a"
 
   llvm_src_version: "22.1.6"
   llvm_version: ${{ llvm_src_version | split(".") | first }}
@@ -149,7 +149,7 @@ recipe:
 
 source:
   - url: https://ziglang.org/builds/zig-${{ version }}-dev.${{ snapshot }}.tar.xz
-    sha256: a7d52940bf1af409f5c0c65053a5d7040a3f18ffc3a954e4e24b027895d4f4fe
+    sha256: 5c3ed47fbb72e25cfd333a2faff4f46d93f3ef8414e570e84d2097c86936bd00
     patches:
       # All platforms: wire LLD MachO into zig cc pipeline + allow -fuse-ld=lld.
       # macho-lld-support must apply before prefer-shared-libcxx because the
@@ -230,32 +230,32 @@ source:
       - if: build_platform == "osx-arm64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: d13865a4ee746c79d08fc1f9a1bd1a788c1423205ea5354403ad40d1386b7aed
+            sha256: 5df52e88cf12224969e0f7314d3c77a598b4eeb6b559df54781eef38d77a29ba
             target_directory: zig-bootstrap
       - if: build_platform == "osx-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: cb78ba744950d6ff0d022469fe5a400c04c19e27c98b44d157c18e829b58eff3
+            sha256: 5312f27941fb6c3b650608517ff9998cb2ff566d36b0868288d99253da373734
             target_directory: zig-bootstrap
       - if: build_platform == "win-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-windows-${{ version }}-dev.${{ snapshot }}.zip
-            sha256: 3fbc43463e0999a2f01ba7a85c6ef49749ceecdda2a8df32c210b2e458a29e28
+            sha256: 0f4aa391a28c34c2727bcd1a0be679685583c633fad9f95e6244659c5c16c8f6
             target_directory: zig-bootstrap
       - if: build_platform == "linux-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: bc92e8b99eeef771c744fe4173e7960bee7c06158d59779fa1e6ed795dccc6ac
+            sha256: 337b81a6e89e8289d31311fd7cfdd53c8bfcb1b8c4b5cfadf3363eabfb9a6daa
             target_directory: zig-bootstrap
       - if: build_platform == "linux-aarch64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 96c3ad5ac06f920b4539a3ad9e4f1c515eee267a609e15ebd70b47fe3577c869
+            sha256: 2e588e32ee3fd8862f17572a716a5bc33b655a10eb99419e2f5b16922d3b9aa8
             target_directory: zig-bootstrap
       - if: build_platform == "linux-ppc64le"
         then:
           - url: https://ziglang.org/builds/zig-powerpc64le-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: a8d0fde3cd752b9f87712b4d6e87ece8186cb36086f353caf87614c7efd1e527
+            sha256: 38896511d061edd1759802487b8ff804375cc4652a724b1935b3052019c474e8
             target_directory: zig-bootstrap
 
 build:


### PR DESCRIPTION
Automated zig master version bump.

- version: 0.17.0 -> 0.17.0
- tarball: https://ziglang.org/builds/zig-0.17.0-dev.1567+f0354179a.tar.xz
- sha256: 5c3ed47fbb72e25cfd333a2faff4f46d93f3ef8414e570e84d2097c86936bd00
- bootstrap sha256s patched: osx-arm64,osx-64,win-64,linux-64,linux-aarch64,linux-ppc64le

Patch relevancy gate:
### linux-64

### win-64


Auto-generated by MementoRC/zig-feedstock's .github/workflows/zig-nightly-snapshot.yml -- verify FAIL/DRIFT/large-OFFSET findings above before merging. Diff is scoped to recipe/recipe.yaml only.