### PR TITLE
[dev] version bump: 1567+f0354179a -> 1606+a06534d73

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,7 +5,7 @@ context:
   name: zig
   version: "0.17.0"
   api_version: ${{ version | split(".") | last }}
-  snapshot: "1567+f0354179a"
+  snapshot: "1606+a06534d73"
 
   llvm_src_version: "22.1.6"
   llvm_version: ${{ llvm_src_version | split(".") | first }}
@@ -149,7 +149,7 @@ recipe:
 
 source:
   - url: https://ziglang.org/builds/zig-${{ version }}-dev.${{ snapshot }}.tar.xz
-    sha256: 5c3ed47fbb72e25cfd333a2faff4f46d93f3ef8414e570e84d2097c86936bd00
+    sha256: 02273862ccb2ff0335416ba9bb30f31977792df5e8e8a5cfffdee2280b22475e
     patches:
       # All platforms: wire LLD MachO into zig cc pipeline + allow -fuse-ld=lld.
       # macho-lld-support must apply before prefer-shared-libcxx because the
@@ -230,32 +230,32 @@ source:
       - if: build_platform == "osx-arm64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 5df52e88cf12224969e0f7314d3c77a598b4eeb6b559df54781eef38d77a29ba
+            sha256: 5628b848867b9d4e889526a00001e138b2360f59edbdbee42dd3096065773c77
             target_directory: zig-bootstrap
       - if: build_platform == "osx-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 5312f27941fb6c3b650608517ff9998cb2ff566d36b0868288d99253da373734
+            sha256: 0f0b745140e55992269052d59425cef63d04341fcf870f696917d5fa73a04caa
             target_directory: zig-bootstrap
       - if: build_platform == "win-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-windows-${{ version }}-dev.${{ snapshot }}.zip
-            sha256: 0f4aa391a28c34c2727bcd1a0be679685583c633fad9f95e6244659c5c16c8f6
+            sha256: 9984edb6c678c0f2e6265e10175011f19ea62b2e7678fe56b6c138e61769c894
             target_directory: zig-bootstrap
       - if: build_platform == "linux-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 337b81a6e89e8289d31311fd7cfdd53c8bfcb1b8c4b5cfadf3363eabfb9a6daa
+            sha256: 25bcb0cf8e31314b798f2b9318e1ccd13ea8bd21f030c734923f263578b8d520
             target_directory: zig-bootstrap
       - if: build_platform == "linux-aarch64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 2e588e32ee3fd8862f17572a716a5bc33b655a10eb99419e2f5b16922d3b9aa8
+            sha256: 968dcb2f6a08e1de36f17a2a06b784b82f16a6ec68a83322876f54d80275a917
             target_directory: zig-bootstrap
       - if: build_platform == "linux-ppc64le"
         then:
           - url: https://ziglang.org/builds/zig-powerpc64le-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 38896511d061edd1759802487b8ff804375cc4652a724b1935b3052019c474e8
+            sha256: 0e255bdc41ccd61c93d8c1ddd699530155b443c364c5e66a07bda891ad7a8b5a
             target_directory: zig-bootstrap
 
 build:


### PR DESCRIPTION
Automated zig master version bump.

- version: 0.17.0 -> 0.17.0
- tarball: https://ziglang.org/builds/zig-0.17.0-dev.1606+a06534d73.tar.xz
- sha256: 02273862ccb2ff0335416ba9bb30f31977792df5e8e8a5cfffdee2280b22475e
- bootstrap sha256s patched: osx-arm64,osx-64,win-64,linux-64,linux-aarch64,linux-ppc64le

Patch relevancy gate:
### linux-64

### win-64


Auto-generated by MementoRC/zig-feedstock's .github/workflows/zig-nightly-snapshot.yml -- verify FAIL/DRIFT/large-OFFSET findings above before merging. Diff is scoped to recipe/recipe.yaml only.