### PR TITLE
[dev] version bump: 1609+11e2bb391 -> 1622+2b242157b

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,7 +5,7 @@ context:
   name: zig
   version: "0.17.0"
   api_version: ${{ version | split(".") | last }}
-  snapshot: "1609+11e2bb391"
+  snapshot: "1622+2b242157b"
 
   llvm_src_version: "22.1.6"
   llvm_version: ${{ llvm_src_version | split(".") | first }}
@@ -149,7 +149,7 @@ recipe:
 
 source:
   - url: https://ziglang.org/builds/zig-${{ version }}-dev.${{ snapshot }}.tar.xz
-    sha256: 93e384bc0687ae55f635f930d1f4b883e3641ffa56444917ef32e59741771d57
+    sha256: 4fdbd5b0e0b4a6dddcb6f98439b5ef482ab95e99cf749a50e1e7dc621ee3e8b6
     patches:
       # All platforms: wire LLD MachO into zig cc pipeline + allow -fuse-ld=lld.
       # macho-lld-support must apply before prefer-shared-libcxx because the
@@ -230,32 +230,32 @@ source:
       - if: build_platform == "osx-arm64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 7b1e292828d33c4f1fc2ca042c84b6bd980b56e0fb638f31f111809d243d728e
+            sha256: 33f5b408db1c2993573ab8ee69de5b27f6aefb14d77c1fe061d5da54eab4cac9
             target_directory: zig-bootstrap
       - if: build_platform == "osx-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: eab2350d8f09504ce0a12dc38ec4f7690a0accd16df030327e37bd4a884f9aeb
+            sha256: 1e07334a7b131618bf9a8c489bd6d31e6fb8639bf95a5a7eab7f6221ea7f37dc
             target_directory: zig-bootstrap
       - if: build_platform == "win-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-windows-${{ version }}-dev.${{ snapshot }}.zip
-            sha256: b064b949a926bf95ebde81fc7bc07620d2471ccfb9093f80e16677da0a7a7ba2
+            sha256: 33c8bc6e5c707f8317cb3c4ef69aedb87d0ba872aa46bed8d1b1b3cc4281a0ee
             target_directory: zig-bootstrap
       - if: build_platform == "linux-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: be19b234c47af01f0333fcb7212a59840c2ba3531ed9374cd79b3695c48a66c9
+            sha256: 9bde4645e8d918eaa840bfcc1c8cfa9b6567cb612f7d5fe4496244e86dee702f
             target_directory: zig-bootstrap
       - if: build_platform == "linux-aarch64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: c6c25da2308723fa2d956c9f2100237d69aadd3297c286851ec928a2fc309b54
+            sha256: d1c76fea2a68db2181573d80b8fafeb90716d0070254f4f49f8d8cbfed294b9f
             target_directory: zig-bootstrap
       - if: build_platform == "linux-ppc64le"
         then:
           - url: https://ziglang.org/builds/zig-powerpc64le-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: b9a0fc803702685970ec761eb4d2f77aa4728c5e2182fe962694c80e4433bfb2
+            sha256: bf6555b84592ba67f2e25977e884a48edfb9bac500441f350601ff329ac98a14
             target_directory: zig-bootstrap
 
 build:


### PR DESCRIPTION
Automated zig master version bump.

- version: 0.17.0 -> 0.17.0
- tarball: https://ziglang.org/builds/zig-0.17.0-dev.1622+2b242157b.tar.xz
- sha256: 4fdbd5b0e0b4a6dddcb6f98439b5ef482ab95e99cf749a50e1e7dc621ee3e8b6
- bootstrap sha256s patched: osx-arm64,osx-64,win-64,linux-64,linux-aarch64,linux-ppc64le

Patch relevancy gate:
### linux-64

### win-64


Auto-generated by MementoRC/zig-feedstock's .github/workflows/zig-nightly-snapshot.yml -- verify FAIL/DRIFT/large-OFFSET findings above before merging. Diff is scoped to recipe/recipe.yaml only.