### PR TITLE
[dev] version bump: 1683+5ceec001b -> 1737+de207594e

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,7 +5,7 @@ context:
   name: zig
   version: "0.17.0"
   api_version: ${{ version | split(".") | last }}
-  snapshot: "1683+5ceec001b"
+  snapshot: "1737+de207594e"
 
   llvm_src_version: "22.1.6"
   llvm_version: ${{ llvm_src_version | split(".") | first }}
@@ -149,7 +149,7 @@ recipe:
 
 source:
   - url: https://ziglang.org/builds/zig-${{ version }}-dev.${{ snapshot }}.tar.xz
-    sha256: 4dd107f1dc8307db6e4667a4665fdf4eabb91ce074e8d90ad574c215129efa70
+    sha256: b1eaaa73a6b540c0735894db0170fa6565c7cf65a61082db52c9446bfc2244f8
     patches:
       # All platforms: wire LLD MachO into zig cc pipeline + allow -fuse-ld=lld.
       # macho-lld-support must apply before prefer-shared-libcxx because the
@@ -235,32 +235,32 @@ source:
       - if: build_platform == "osx-arm64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 1081a0318a97f492aaca1b76c4e6fe1ce5cd586a212ee2c0db364b05a29b5870
+            sha256: 78fb9f0e0f19f789ae45e8ac5d1c56b88499e0d476ac08f004ba2de4777e1f91
             target_directory: zig-bootstrap
       - if: build_platform == "osx-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-macos-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 2b154b47ce5396c000260c06c8cf018a4bf22dd5f858fc8538e27f2012d86536
+            sha256: d7af186910ea7187a8b2834977b7b9f657b47aca952120c2bf280b2a14a134b9
             target_directory: zig-bootstrap
       - if: build_platform == "win-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-windows-${{ version }}-dev.${{ snapshot }}.zip
-            sha256: f5291dff1dec0ff16bffec0427b0a2b8629080cf2b89d55721b59eef988d3090
+            sha256: be87c7b47ccd60e50a66d262e2aac7a07c1172d1ebf9ba153ba59d483a9b7107
             target_directory: zig-bootstrap
       - if: build_platform == "linux-64"
         then:
           - url: https://ziglang.org/builds/zig-x86_64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: e6e5c7e0834626bded90cd786d148bebf211dc80b013afefd631472b57b41f77
+            sha256: a68df95449e152d78ad3940643fb16b925d273411164295cfa12a4621e85b1da
             target_directory: zig-bootstrap
       - if: build_platform == "linux-aarch64"
         then:
           - url: https://ziglang.org/builds/zig-aarch64-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: b18bd9c61b751ec64982359f85c3d4aec3347f4988b9edbfc15a14c055452eee
+            sha256: 7eb453c50953e16d6aa2b5b7bcce651491fff25aea4313559f685b95ad8bbf15
             target_directory: zig-bootstrap
       - if: build_platform == "linux-ppc64le"
         then:
           - url: https://ziglang.org/builds/zig-powerpc64le-linux-${{ version }}-dev.${{ snapshot }}.tar.xz
-            sha256: 965d9ec626541a4df641625f220678d87dd0899b9850b51d8b5e9b0a69dec166
+            sha256: 05eaaada03b87e1d90bbfdd2ca1c984b83cda32cc6f662675adafbac79d8790d
             target_directory: zig-bootstrap
 
 build:


### PR DESCRIPTION
Automated zig master version bump.

- version: 0.17.0 -> 0.17.0
- tarball: https://ziglang.org/builds/zig-0.17.0-dev.1737+de207594e.tar.xz
- sha256: b1eaaa73a6b540c0735894db0170fa6565c7cf65a61082db52c9446bfc2244f8
- bootstrap sha256s patched: osx-arm64,osx-64,win-64,linux-64,linux-aarch64,linux-ppc64le

Patch relevancy gate:
### linux-64

### win-64


Auto-generated by MementoRC/zig-feedstock's .github/workflows/zig-nightly-snapshot.yml -- verify FAIL/DRIFT/large-OFFSET findings above before merging. Diff is scoped to recipe/recipe.yaml only.